### PR TITLE
fix: prevent duplicate toast listeners

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure toast hook only registers a single listener

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompted for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a09eb48a3c832e8e19cc98f70f0ce6