### PR TITLE
fix: correct BreadcrumbEllipsis display name

### DIFF
--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -102,7 +102,7 @@ const BreadcrumbEllipsis = ({
     <span className="sr-only">More</span>
   </span>
 )
-BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+BreadcrumbEllipsis.displayName = "BreadcrumbEllipsis"
 
 export {
   Breadcrumb,


### PR DESCRIPTION
## Summary
- fix BreadcrumbEllipsis display name string

## Testing
- `pnpm run test` *(fails: ERR_PNPM_NO_SCRIPT Missing script: test)*
- `pnpm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a48fee6c832ea79700f2ccc199bb