### PR TITLE
fix: unify mobile breakpoint logic

### DIFF
--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -40,8 +40,8 @@ export function useDeviceType() {
     const updateDeviceType = () => {
       const width = window.innerWidth
       setDeviceType({
-        isMobile: width < breakpoints.sm,
-        isTablet: width >= breakpoints.sm && width < breakpoints.lg,
+        isMobile: width < breakpoints.md,
+        isTablet: width >= breakpoints.md && width < breakpoints.lg,
         isDesktop: width >= breakpoints.lg && width < breakpoints.xl,
         isLargeDesktop: width >= breakpoints.xl,
       })


### PR DESCRIPTION
## Summary
- unify mobile detection logic to use md breakpoint and adjust tablet range accordingly

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a496c5e0832ea368916516543d84