### PR TITLE
refactor: replace purple utilities with new color palette

### DIFF
--- a/app/auth/auth-context.tsx
+++ b/app/auth/auth-context.tsx
@@ -172,7 +172,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           category: "Entertainment",
           options: [
             { id: "option_4_1", name: "Contestant #1", percentage: 30, tokens: 3000, color: "bg-kai-600" },
-            { id: "option_4_2", name: "Contestant #2", percentage: 40, tokens: 4000, color: "bg-purple-400" },
+            { id: "option_4_2", name: "Contestant #2", percentage: 40, tokens: 4000, color: "bg-primary-400" },
             { id: "option_4_3", name: "Contestant #3", percentage: 30, tokens: 3000, color: "bg-blue-400" }
           ],
           startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 1 week ago

--- a/app/components/contextual-help.tsx
+++ b/app/components/contextual-help.tsx
@@ -105,7 +105,7 @@ export function ContextualHelp({ context }: ContextualHelpProps) {
   return (
     <div className="fixed bottom-4 left-4 z-40">
       <Card className="w-80 bg-white shadow-xl border-0 rounded-2xl overflow-hidden">
-        <div className="bg-gradient-to-r from-blue-400 to-purple-400 p-4 text-white">
+        <div className="bg-gradient-to-r from-blue-400 to-primary-400 p-4 text-white">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <HelpCircle className="w-5 h-5" />

--- a/app/components/featured-markets.tsx
+++ b/app/components/featured-markets.tsx
@@ -145,7 +145,7 @@ export function FeaturedMarkets({
               <div className="flex items-center justify-between mb-4">
                 <Badge 
                   variant="secondary" 
-                  className="bg-purple-100 text-purple-700 hover:bg-purple-200 font-medium"
+                  className="bg-primary-100 text-primary-700 hover:bg-primary-200 font-medium"
                 >
                   {market.category}
                 </Badge>

--- a/app/components/onboarding-flow.tsx
+++ b/app/components/onboarding-flow.tsx
@@ -76,7 +76,7 @@ export function OnboardingFlow() {
                   <span className="text-sm font-semibold">55%</span>
                 </div>
                 <div className="w-full bg-gray-200 rounded-full h-2">
-                  <div className="bg-purple-400 h-2 rounded-full" style={{ width: "55%" }} />
+                  <div className="bg-primary-400 h-2 rounded-full" style={{ width: "55%" }} />
                 </div>
               </div>
             </div>
@@ -93,7 +93,7 @@ export function OnboardingFlow() {
     {
       title: "Connect with Others",
       description: "Engage with a community that shares your interests.",
-      icon: <Users className="h-12 w-12 text-purple-500" />,
+      icon: <Users className="h-12 w-12 text-primary-500" />,
       content: (
         <div className="space-y-4">
           <p className="text-gray-600">
@@ -114,8 +114,8 @@ export function OnboardingFlow() {
           </div>
           <div className="bg-gray-50 rounded-xl p-3">
             <div className="flex items-center gap-2 mb-2">
-              <div className="w-6 h-6 rounded-full bg-purple-100 flex items-center justify-center">
-                <span className="text-xs text-purple-600">A</span>
+              <div className="w-6 h-6 rounded-full bg-primary-100 flex items-center justify-center">
+                <span className="text-xs text-primary-600">A</span>
               </div>
               <span className="text-sm font-medium">Amara J.</span>
             </div>
@@ -185,7 +185,7 @@ export function OnboardingFlow() {
   const currentStepData = steps[currentStep - 1]
 
   return (
-    <div className="fixed inset-0 bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50 flex items-center justify-center p-4 z-50">
+    <div className="fixed inset-0 bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50 flex items-center justify-center p-4 z-50">
       <Card className="w-full max-w-md bg-white rounded-3xl shadow-xl overflow-hidden">
         <div className="p-6">
           <div className="flex items-center justify-between mb-4">

--- a/app/components/token-reward-animation.tsx
+++ b/app/components/token-reward-animation.tsx
@@ -23,7 +23,7 @@ export function TokenRewardAnimation({
   const colors = {
     win: "text-amber-500",
     prediction: "text-kai-500",
-    bonus: "text-purple-500"
+    bonus: "text-primary-500"
   }
 
   // Define sizes

--- a/app/components/trending-markets.tsx
+++ b/app/components/trending-markets.tsx
@@ -51,7 +51,7 @@ export function TrendingMarkets({
       case 'viral':
         return {
           icon: <Zap className="h-3 w-3" />,
-          className: "bg-purple-100 text-purple-700 border-purple-200",
+          className: "bg-primary-100 text-primary-700 border-primary-200",
           label: "Viral"
         }
       case 'hot':
@@ -239,7 +239,7 @@ export function TrendingMarkets({
                 
                 {/* Category and growth rate */}
                 <div className="flex flex-wrap gap-2 mb-3">
-                  <Badge variant="secondary" className="bg-purple-100 text-purple-700 hover:bg-purple-200 text-xs">
+                  <Badge variant="secondary" className="bg-primary-100 text-primary-700 hover:bg-primary-200 text-xs">
                     {market.category}
                   </Badge>
                   {market.growthRate > 50 && (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -18,7 +18,7 @@ const mockPredictions = [
     description: "The ultimate showdown is here! Which housemate has captured viewers' hearts?",
     options: [
       { name: "Mercy", percentage: 45, tokens: 12500, color: "bg-kai-600" },
-      { name: "Tacha", percentage: 35, tokens: 9800, color: "bg-purple-400" },
+      { name: "Tacha", percentage: 35, tokens: 9800, color: "bg-primary-400" },
       { name: "Nengi", percentage: 20, tokens: 5600, color: "bg-blue-400" },
     ],
     category: "BBNaija",
@@ -75,13 +75,13 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
 
       {/* Mobile Layout */}
       <div className="md:hidden">
         <div className="min-h-screen pb-20">
           {/* Mobile Header */}
-          <div className="bg-gradient-to-r from-kai-500 via-purple-500 to-gold-500 p-4 text-white">
+          <div className="bg-gradient-to-r from-kai-500 via-primary-500 to-gold-500 p-4 text-white">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-3">
                 <Avatar className="h-12 w-12 border-2 border-white/30">
@@ -165,7 +165,7 @@ export default function DashboardPage() {
                             {prediction.category}
                           </Badge>
                           {prediction.trending && (
-                            <Badge className="bg-gradient-to-r from-kai-600 to-purple-400 text-white text-xs">
+                            <Badge className="bg-gradient-to-r from-kai-600 to-primary-400 text-white text-xs">
                               Trending
                             </Badge>
                           )}
@@ -287,7 +287,7 @@ export default function DashboardPage() {
           {/* Desktop Hero Section */}
           <div className="grid grid-cols-12 gap-8 mb-8">
             <div className="col-span-8">
-              <Card className="border-0 shadow-xl bg-gradient-to-br from-kai-500 via-purple-500 to-gold-500 text-white overflow-hidden relative">
+              <Card className="border-0 shadow-xl bg-gradient-to-br from-kai-500 via-primary-500 to-gold-500 text-white overflow-hidden relative">
                 <CardContent className="p-8 relative">
                   <div className="flex items-center gap-3 mb-4">
                     <Avatar className="h-16 w-16 border-3 border-white/30">
@@ -360,8 +360,8 @@ export default function DashboardPage() {
               <Card className="border-0 shadow-lg">
                 <CardContent className="p-6">
                   <div className="flex items-center gap-3 mb-4">
-                    <div className="w-12 h-12 bg-gradient-to-r from-purple-100 to-pink-100 rounded-xl flex items-center justify-center">
-                      <Heart className="w-6 h-6 text-purple-600" />
+                    <div className="w-12 h-12 bg-gradient-to-r from-primary-100 to-pink-100 rounded-xl flex items-center justify-center">
+                      <Heart className="w-6 h-6 text-primary-600" />
                     </div>
                     <div>
                       <h3 className="font-bold text-gray-900">Community Love</h3>
@@ -408,7 +408,7 @@ export default function DashboardPage() {
                                   {prediction.category}
                                 </Badge>
                                 {prediction.trending && (
-                                  <Badge className="bg-gradient-to-r from-kai-600 to-purple-400 text-white text-xs">
+                                  <Badge className="bg-gradient-to-r from-kai-600 to-primary-400 text-white text-xs">
                                     Trending
                                   </Badge>
                                 )}

--- a/app/markets/[id]/market-detail-view.tsx
+++ b/app/markets/[id]/market-detail-view.tsx
@@ -66,7 +66,7 @@ export function MarketDetailView({ market }: MarketDetailViewProps) {
   // Get trending indicator
   const getTrendingIndicator = (market: Market) => {
     if (market.participants >= 400) {
-      return { icon: <Zap className="h-4 w-4" />, label: "Viral", className: "bg-purple-100 text-purple-700 border-purple-200" }
+      return { icon: <Zap className="h-4 w-4" />, label: "Viral", className: "bg-primary-100 text-primary-700 border-primary-200" }
     } else if (market.totalTokens >= 20000) {
       return { icon: <Flame className="h-4 w-4" />, label: "Hot", className: "bg-red-100 text-red-700 border-red-200" }
     } else if (market.participants >= 200) {
@@ -104,7 +104,7 @@ export function MarketDetailView({ market }: MarketDetailViewProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
       <div className="max-w-4xl mx-auto px-4 py-6">
         {/* Back button */}
         <Button

--- a/app/markets/[id]/market-statistics.tsx
+++ b/app/markets/[id]/market-statistics.tsx
@@ -107,7 +107,7 @@ export function MarketStatistics({ market }: MarketStatisticsProps) {
         {/* Option breakdown */}
         <div>
           <h4 className="font-medium text-gray-800 mb-3 flex items-center">
-            <PieChart className="h-4 w-4 mr-2 text-purple-500" />
+            <PieChart className="h-4 w-4 mr-2 text-primary-500" />
             Option Breakdown
           </h4>
           

--- a/app/markets/[id]/page.tsx
+++ b/app/markets/[id]/page.tsx
@@ -46,7 +46,7 @@ export default function MarketDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
         <div className="max-w-4xl mx-auto px-4 py-6">
           <div className="animate-pulse">
             <div className="h-8 bg-gray-200 rounded w-1/4 mb-6"></div>
@@ -61,7 +61,7 @@ export default function MarketDetailPage() {
 
   if (error || !market) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
         <div className="max-w-4xl mx-auto px-4 py-6">
           <Button
             variant="ghost"

--- a/app/markets/[id]/related-markets.tsx
+++ b/app/markets/[id]/related-markets.tsx
@@ -104,7 +104,7 @@ export function RelatedMarkets({ currentMarket }: RelatedMarketsProps) {
 
   const getTrendingIndicator = (market: Market) => {
     if (market.participants >= 400) {
-      return { icon: <Flame className="h-3 w-3" />, label: "Viral", className: "bg-purple-100 text-purple-700" }
+      return { icon: <Flame className="h-3 w-3" />, label: "Viral", className: "bg-primary-100 text-primary-700" }
     } else if (market.totalTokens >= 20000) {
       return { icon: <Flame className="h-3 w-3" />, label: "Hot", className: "bg-red-100 text-red-700" }
     } else if (market.participants >= 200) {
@@ -206,7 +206,7 @@ export function RelatedMarkets({ currentMarket }: RelatedMarketsProps) {
                   
                   {/* Category and trending indicator */}
                   <div className="flex flex-wrap gap-1 mb-3">
-                    <Badge variant="secondary" className="bg-purple-100 text-purple-700 text-xs">
+                    <Badge variant="secondary" className="bg-primary-100 text-primary-700 text-xs">
                       {market.category}
                     </Badge>
                     {trendingIndicator && (

--- a/app/markets/create/market-creation-form.tsx
+++ b/app/markets/create/market-creation-form.tsx
@@ -36,7 +36,7 @@ const marketCategories = [
 // Define option colors
 const optionColors = [
   { name: "Sage", value: "bg-kai-400" },
-  { name: "Purple", value: "bg-purple-400" },
+  { name: "Purple", value: "bg-primary-400" },
   { name: "Blue", value: "bg-blue-400" },
   { name: "Green", value: "bg-green-400" },
   { name: "Orange", value: "bg-orange-400" },
@@ -62,7 +62,7 @@ export function MarketCreationForm() {
   const [endDate, setEndDate] = useState<Date | undefined>(undefined)
   const [options, setOptions] = useState([
     { id: "1", name: "", color: "bg-kai-400" },
-    { id: "2", name: "", color: "bg-purple-400" }
+    { id: "2", name: "", color: "bg-primary-400" }
   ])
   const [creatorRewardPercentage] = useState(5) // Fixed at 5% for now
   const [tags, setTags] = useState<string[]>([])

--- a/app/markets/create/market-templates.ts
+++ b/app/markets/create/market-templates.ts
@@ -35,7 +35,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "General",
     options: [
       { name: "Option 1", color: "bg-kai-600" },
-      { name: "Option 2", color: "bg-purple-400" },
+      { name: "Option 2", color: "bg-primary-400" },
       { name: "Option 3", color: "bg-blue-400" }
     ],
     icon: "List"
@@ -47,7 +47,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Entertainment",
     options: [
       { name: "They'll stay together", color: "bg-kai-600" },
-      { name: "They'll break up", color: "bg-purple-400" }
+      { name: "They'll break up", color: "bg-primary-400" }
     ],
     icon: "Heart"
   },
@@ -58,7 +58,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Entertainment",
     options: [
       { name: "Contestant 1", color: "bg-kai-600" },
-      { name: "Contestant 2", color: "bg-purple-400" },
+      { name: "Contestant 2", color: "bg-primary-400" },
       { name: "Contestant 3", color: "bg-blue-400" },
       { name: "Contestant 4", color: "bg-green-400" }
     ],
@@ -71,7 +71,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Fashion",
     options: [
       { name: "It will be huge", color: "bg-kai-600" },
-      { name: "Limited popularity", color: "bg-purple-400" },
+      { name: "Limited popularity", color: "bg-primary-400" },
       { name: "It will flop", color: "bg-red-400" }
     ],
     icon: "Shirt"
@@ -83,7 +83,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Music",
     options: [
       { name: "Within 3 months", color: "bg-kai-600" },
-      { name: "3-6 months", color: "bg-purple-400" },
+      { name: "3-6 months", color: "bg-primary-400" },
       { name: "6-12 months", color: "bg-blue-400" },
       { name: "More than a year", color: "bg-green-400" }
     ],
@@ -109,7 +109,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Social Media",
     options: [
       { name: "Within a month", color: "bg-kai-600" },
-      { name: "1-3 months", color: "bg-purple-400" },
+      { name: "1-3 months", color: "bg-primary-400" },
       { name: "3-6 months", color: "bg-blue-400" },
       { name: "More than 6 months", color: "bg-green-400" }
     ],
@@ -122,7 +122,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Entertainment",
     options: [
       { name: "Nominee 1", color: "bg-kai-600" },
-      { name: "Nominee 2", color: "bg-purple-400" },
+      { name: "Nominee 2", color: "bg-primary-400" },
       { name: "Nominee 3", color: "bg-blue-400" },
       { name: "Dark horse winner", color: "bg-green-400" }
     ],
@@ -135,7 +135,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Celebrity",
     options: [
       { name: "They'll get engaged", color: "bg-kai-600" },
-      { name: "They'll stay together", color: "bg-purple-400" },
+      { name: "They'll stay together", color: "bg-primary-400" },
       { name: "They'll break up", color: "bg-red-400" }
     ],
     icon: "Heart"
@@ -173,7 +173,7 @@ export const marketTemplates: MarketTemplate[] = [
     category: "Fashion",
     options: [
       { name: "Next big thing", color: "bg-kai-600" },
-      { name: "Niche popularity", color: "bg-purple-400" },
+      { name: "Niche popularity", color: "bg-primary-400" },
       { name: "Short-lived fad", color: "bg-orange-400" }
     ],
     icon: "Sparkles"

--- a/app/markets/create/sample-markets.ts
+++ b/app/markets/create/sample-markets.ts
@@ -24,7 +24,7 @@ export const sampleMarkets: Market[] = [
     category: "TV Shows",
     options: [
       { id: "option_2_1", name: "Contestant #1", percentage: 25, tokens: 2000, color: "bg-kai-600" },
-      { id: "option_2_2", name: "Contestant #2", percentage: 40, tokens: 3200, color: "bg-purple-400" },
+      { id: "option_2_2", name: "Contestant #2", percentage: 40, tokens: 3200, color: "bg-primary-400" },
       { id: "option_2_3", name: "Contestant #3", percentage: 35, tokens: 2800, color: "bg-blue-400" }
     ],
     startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
@@ -40,7 +40,7 @@ export const sampleMarkets: Market[] = [
     category: "Music",
     options: [
       { id: "option_3_1", name: "Yes, within 3 months", percentage: 30, tokens: 1800, color: "bg-kai-600" },
-      { id: "option_3_2", name: "Yes, but later this year", percentage: 45, tokens: 2700, color: "bg-purple-400" },
+      { id: "option_3_2", name: "Yes, but later this year", percentage: 45, tokens: 2700, color: "bg-primary-400" },
       { id: "option_3_3", name: "No announcement this year", percentage: 25, tokens: 1500, color: "bg-blue-400" }
     ],
     startDate: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), // 30 days ago
@@ -57,7 +57,7 @@ export const sampleMarkets: Market[] = [
     options: [
       { id: "option_4_1", name: "Y2K Revival", percentage: 40, tokens: 3600, color: "bg-kai-600" },
       { id: "option_4_2", name: "Sustainable Fashion", percentage: 35, tokens: 3150, color: "bg-green-400" },
-      { id: "option_4_3", name: "Maximalism", percentage: 25, tokens: 2250, color: "bg-purple-400" }
+      { id: "option_4_3", name: "Maximalism", percentage: 25, tokens: 2250, color: "bg-primary-400" }
     ],
     startDate: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000), // 10 days ago
     endDate: new Date(Date.now() + 80 * 24 * 60 * 60 * 1000), // 80 days from now
@@ -87,7 +87,7 @@ export const sampleMarkets: Market[] = [
     category: "Celebrity",
     options: [
       { id: "option_6_1", name: "Couple #1", percentage: 30, tokens: 2400, color: "bg-kai-600" },
-      { id: "option_6_2", name: "Couple #2", percentage: 45, tokens: 3600, color: "bg-purple-400" },
+      { id: "option_6_2", name: "Couple #2", percentage: 45, tokens: 3600, color: "bg-primary-400" },
       { id: "option_6_3", name: "Couple #3", percentage: 25, tokens: 2000, color: "bg-blue-400" }
     ],
     startDate: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), // 3 days ago
@@ -103,7 +103,7 @@ export const sampleMarkets: Market[] = [
     category: "Movies",
     options: [
       { id: "option_7_1", name: "Movie #1", percentage: 20, tokens: 1600, color: "bg-kai-600" },
-      { id: "option_7_2", name: "Movie #2", percentage: 35, tokens: 2800, color: "bg-purple-400" },
+      { id: "option_7_2", name: "Movie #2", percentage: 35, tokens: 2800, color: "bg-primary-400" },
       { id: "option_7_3", name: "Movie #3", percentage: 30, tokens: 2400, color: "bg-blue-400" },
       { id: "option_7_4", name: "Movie #4", percentage: 15, tokens: 1200, color: "bg-green-400" }
     ],
@@ -120,7 +120,7 @@ export const sampleMarkets: Market[] = [
     category: "Social Media",
     options: [
       { id: "option_8_1", name: "TikTok", percentage: 45, tokens: 4500, color: "bg-kai-600" },
-      { id: "option_8_2", name: "Instagram", percentage: 30, tokens: 3000, color: "bg-purple-400" },
+      { id: "option_8_2", name: "Instagram", percentage: 30, tokens: 3000, color: "bg-primary-400" },
       { id: "option_8_3", name: "Twitter/X", percentage: 15, tokens: 1500, color: "bg-blue-400" },
       { id: "option_8_4", name: "BeReal", percentage: 10, tokens: 1000, color: "bg-green-400" }
     ],

--- a/app/markets/discover/market-grid.tsx
+++ b/app/markets/discover/market-grid.tsx
@@ -74,7 +74,7 @@ export function MarketGrid({ markets, isLoading }: MarketGridProps) {
   // Get trending indicator
   const getTrendingIndicator = (market: Market) => {
     if (market.participants >= 400) {
-      return { icon: <Zap className="h-3 w-3" />, label: "Viral", className: "bg-purple-100 text-purple-700" }
+      return { icon: <Zap className="h-3 w-3" />, label: "Viral", className: "bg-primary-100 text-primary-700" }
     } else if (market.totalTokens >= 20000) {
       return { icon: <Flame className="h-3 w-3" />, label: "Hot", className: "bg-red-100 text-red-700" }
     } else if (market.participants >= 200) {
@@ -166,7 +166,7 @@ export function MarketGrid({ markets, isLoading }: MarketGridProps) {
             
             {/* Category, trending indicator, and time remaining */}
             <div className="flex flex-wrap gap-2 mb-3">
-              <Badge variant="secondary" className="bg-purple-100 text-purple-700 hover:bg-purple-200">
+              <Badge variant="secondary" className="bg-primary-100 text-primary-700 hover:bg-primary-200">
                 {market.category}
               </Badge>
               {(() => {

--- a/app/markets/discover/page.tsx
+++ b/app/markets/discover/page.tsx
@@ -121,7 +121,7 @@ export default function MarketDiscoveryPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
       <div className="max-w-7xl mx-auto px-4 py-6 md:py-8 lg:py-12">
         <MarketDiscoveryHeader />
         

--- a/app/markets/trending/page.tsx
+++ b/app/markets/trending/page.tsx
@@ -29,7 +29,7 @@ export default function TrendingMarketsPage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
       <div className="max-w-7xl mx-auto px-4 py-6 md:py-8 lg:py-12">
         <TrendingMarkets 
           markets={trendingMarkets}

--- a/app/profile/edit-profile-page.tsx
+++ b/app/profile/edit-profile-page.tsx
@@ -51,7 +51,7 @@ export default function EditProfilePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
       
       {/* Mobile Layout */}
       <div className="md:hidden">

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -85,7 +85,7 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
 
       {/* Mobile Layout */}
       <div className="md:hidden">
@@ -228,7 +228,7 @@ export default function ProfilePage() {
                                     <Badge className="bg-kai-100 text-kai-700 text-xs">Prediction</Badge>
                                   )}
                                   {activity.type === 'market' && (
-                                    <Badge className="bg-purple-100 text-purple-700 text-xs">Market</Badge>
+                                    <Badge className="bg-primary-100 text-primary-700 text-xs">Market</Badge>
                                   )}
                                 </div>
                                 <p className="text-sm">{activity.title}</p>
@@ -498,8 +498,8 @@ export default function ProfilePage() {
 
             <Card className="border-0 shadow-lg hover:shadow-xl transition-shadow">
               <CardContent className="p-6 text-center">
-                <div className="w-16 h-16 bg-purple-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
-                  <BarChart3 className="w-8 h-8 text-purple-600" />
+                <div className="w-16 h-16 bg-primary-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                  <BarChart3 className="w-8 h-8 text-primary-600" />
                 </div>
                 <p className="text-3xl font-bold text-gray-900 mb-1">{user?.stats?.marketsCreated || 0}</p>
                 <p className="text-gray-600">Markets Created</p>
@@ -570,11 +570,11 @@ export default function ProfilePage() {
                           <div key={activity.id} className="flex items-center gap-4 p-4 rounded-lg hover:bg-gray-50 transition-colors">
                             <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${activity.type === 'win' ? 'bg-green-100' :
                               activity.type === 'prediction' ? 'bg-kai-100' :
-                                'bg-purple-100'
+                                'bg-primary-100'
                               }`}>
                               {activity.type === 'win' && <Award className="w-6 h-6 text-green-600" />}
                               {activity.type === 'prediction' && <TrendingUp className="w-6 h-6 text-kai-600" />}
-                              {activity.type === 'market' && <BarChart3 className="w-6 h-6 text-purple-600" />}
+                              {activity.type === 'market' && <BarChart3 className="w-6 h-6 text-primary-600" />}
                             </div>
                             <div className="flex-1">
                               <div className="flex items-center gap-2 mb-1">
@@ -585,7 +585,7 @@ export default function ProfilePage() {
                                   <Badge className="bg-kai-100 text-kai-700">Prediction</Badge>
                                 )}
                                 {activity.type === 'market' && (
-                                  <Badge className="bg-purple-100 text-purple-700">Market</Badge>
+                                  <Badge className="bg-primary-100 text-primary-700">Market</Badge>
                                 )}
                               </div>
                               <p className="font-medium text-gray-900">{activity.title}</p>
@@ -820,7 +820,7 @@ export default function ProfilePage() {
                         name: "Market Creator",
                         icon: <Building className="w-5 h-5" />,
                         earned: (user?.stats?.marketsCreated || 0) > 0,
-                        color: "text-purple-600"
+                        color: "text-primary-600"
                       },
                       {
                         name: "High Roller",

--- a/app/social/page.tsx
+++ b/app/social/page.tsx
@@ -173,7 +173,7 @@ export default function SocialPage() {
       case "win":
         return <Sparkles className="w-4 h-4 text-green-500" />
       case "market_created":
-        return <Users className="w-4 h-4 text-purple-500" />
+        return <Users className="w-4 h-4 text-primary-500" />
       case "comment":
         return <MessageCircle className="w-4 h-4 text-blue-500" />
       default:
@@ -198,7 +198,7 @@ export default function SocialPage() {
 
   if (isLoading || !isAuthenticated) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50 flex items-center justify-center">
         <div className="text-center">
           <div className="text-3xl font-bold bg-gradient-to-r from-primary-400 to-kai-500 text-transparent bg-clip-text mb-4">
             KAI
@@ -210,7 +210,7 @@ export default function SocialPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
       
       {/* Mobile Layout */}
       <div className="md:hidden">
@@ -511,7 +511,7 @@ export default function SocialPage() {
               <Card className="border-0 shadow-lg">
                 <CardHeader>
                   <h3 className="font-bold text-gray-900 flex items-center gap-2">
-                    <UserPlus className="w-5 h-5 text-purple-500" />
+                    <UserPlus className="w-5 h-5 text-primary-500" />
                     Who to Follow
                   </h3>
                 </CardHeader>
@@ -601,7 +601,7 @@ export default function SocialPage() {
                                 <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${
                                   post.type === 'prediction' ? 'bg-kai-100 text-kai-700' :
                                   post.type === 'win' ? 'bg-green-100 text-green-700' :
-                                  post.type === 'market_created' ? 'bg-purple-100 text-purple-700' :
+                                  post.type === 'market_created' ? 'bg-primary-100 text-primary-700' :
                                   'bg-blue-100 text-blue-700'
                                 }`}>
                                   {getPostIcon(post.type)}
@@ -760,8 +760,8 @@ export default function SocialPage() {
                     </div>
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-2">
-                        <div className="w-8 h-8 bg-purple-100 rounded-lg flex items-center justify-center">
-                          <Users className="w-4 h-4 text-purple-600" />
+                        <div className="w-8 h-8 bg-primary-100 rounded-lg flex items-center justify-center">
+                          <Users className="w-4 h-4 text-primary-600" />
                         </div>
                         <span className="text-sm text-gray-600">Online Users</span>
                       </div>

--- a/app/trending/page.tsx
+++ b/app/trending/page.tsx
@@ -46,7 +46,7 @@ export default function TrendingPage() {
 
   if (isLoading || !isAuthenticated) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50 flex items-center justify-center">
         <div className="text-center">
           <div className="text-3xl font-bold bg-gradient-to-r from-primary-400 to-kai-500 text-transparent bg-clip-text mb-4">
             KAI
@@ -64,7 +64,7 @@ export default function TrendingPage() {
     : trendingMarkets.filter(market => market.category === selectedCategory)
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
       <div className="max-w-4xl md:max-w-6xl mx-auto px-4 py-6 pb-24 md:pb-6 md:pt-8">
         {/* Mobile Header */}
         <div className="md:hidden flex items-center gap-3 mb-6">
@@ -139,9 +139,9 @@ export default function TrendingPage() {
               <p className="text-xs text-gray-600">Trending Markets</p>
             </CardContent>
           </Card>
-          <Card className="border-0 shadow-sm bg-gradient-to-br from-purple-50 to-indigo-50">
+          <Card className="border-0 shadow-sm bg-gradient-to-br from-primary-50 to-indigo-50">
             <CardContent className="p-4 text-center">
-              <Users className="w-6 h-6 text-purple-500 mx-auto mb-2" />
+              <Users className="w-6 h-6 text-primary-500 mx-auto mb-2" />
               <p className="text-2xl font-bold text-gray-800">
                 {trendingMarkets.reduce((sum, market) => sum + market.participants, 0).toLocaleString()}
               </p>
@@ -213,7 +213,7 @@ export default function TrendingPage() {
                           market.popularityIndicator === 'viral' ? 'bg-gradient-to-r from-red-400 to-kai-600' :
                           market.popularityIndicator === 'hot' ? 'bg-gradient-to-r from-orange-400 to-red-400' :
                           market.popularityIndicator === 'rising' ? 'bg-gradient-to-r from-green-400 to-blue-400' :
-                          'bg-gradient-to-r from-purple-400 to-kai-600'
+                          'bg-gradient-to-r from-primary-400 to-kai-600'
                         }`}>
                           {market.popularityIndicator === 'viral' ? '🔥 Viral' :
                            market.popularityIndicator === 'hot' ? '🔥 Hot' :

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -87,7 +87,7 @@ export default function WalletPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 via-kai-50 to-primary-50">
       
       {/* Mobile Layout */}
       <div className="md:hidden">
@@ -170,10 +170,10 @@ export default function WalletPage() {
                 <p className="text-xs font-medium text-gray-700">Withdraw</p>
               </CardContent>
             </Card>
-            <Card className="border-0 shadow-sm bg-gradient-to-br from-purple-50 to-kai-50">
+            <Card className="border-0 shadow-sm bg-gradient-to-br from-primary-50 to-kai-50">
               <CardContent className="p-4 text-center">
-                <div className="w-10 h-10 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-2">
-                  <Sparkles className="w-5 h-5 text-purple-600" />
+                <div className="w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-2">
+                  <Sparkles className="w-5 h-5 text-primary-600" />
                 </div>
                 <p className="text-xs font-medium text-gray-700">Rewards</p>
               </CardContent>
@@ -389,8 +389,8 @@ export default function WalletPage() {
               <Card className="border-0 shadow-lg">
                 <CardContent className="p-6">
                   <div className="flex items-center gap-3">
-                    <div className="w-12 h-12 bg-purple-100 rounded-xl flex items-center justify-center">
-                      <Gift className="w-6 h-6 text-purple-600" />
+                    <div className="w-12 h-12 bg-primary-100 rounded-xl flex items-center justify-center">
+                      <Gift className="w-6 h-6 text-primary-600" />
                     </div>
                     <div>
                       <p className="text-2xl font-bold text-gray-900">1,250</p>
@@ -437,15 +437,15 @@ export default function WalletPage() {
                 </Button>
                 
                 <Button 
-                  className="w-full justify-start bg-purple-50 text-purple-700 hover:bg-purple-100 border-purple-200 h-14"
+                  className="w-full justify-start bg-primary-50 text-primary-700 hover:bg-primary-100 border-primary-200 h-14"
                   variant="outline"
                 >
-                  <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center mr-3">
-                    <Gift className="w-5 h-5 text-purple-600" />
+                  <div className="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center mr-3">
+                    <Gift className="w-5 h-5 text-primary-600" />
                   </div>
                   <div className="text-left">
                     <p className="font-semibold">View Rewards</p>
-                    <p className="text-xs text-purple-600">Check your bonuses</p>
+                    <p className="text-xs text-primary-600">Check your bonuses</p>
                   </div>
                 </Button>
               </div>

--- a/lib/design-tokens.ts
+++ b/lib/design-tokens.ts
@@ -128,7 +128,7 @@ export const componentTokens = {
   // Button variants
   button: {
     primary: 'bg-kai-600 hover:bg-kai-700 text-white rounded-kai-button',
-    secondary: 'bg-kpurple-600 hover:bg-kpurple-700 text-white rounded-kai-button',
+    secondary: 'bg-primary-600 hover:bg-primary-700 text-white rounded-kai-button',
     outline: 'border-2 border-kai-300 text-kai-700 hover:bg-kai-50 rounded-kai-button',
     ghost: 'text-kai-700 hover:bg-kai-50 rounded-kai-button',
     link: 'text-kai-600 hover:text-kai-800 underline',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -69,7 +69,7 @@ export function truncateText(text: string, maxLength: number): string {
  * Generate a random color from the KAI palette
  */
 export function randomKaiColor(): string {
-  const colors = ['kai', 'kpurple', 'coral', 'kteal']
+  const colors = ['kai', 'primary', 'coral', 'kteal']
   const shades = [300, 400, 500, 600]
   
   const randomColor = colors[Math.floor(Math.random() * colors.length)]


### PR DESCRIPTION
## Summary
- replace Tailwind `purple` utilities with `primary` variants across app
- remove `kpurple` references in design tokens and utilities
- align badges and gradients with sage/cream palette

## Testing
- `npm run lint` *(fails: requires ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a118be28832eacc3da61874acd85