### PR TITLE
feat: hook up markets to api

### DIFF
--- a/app/api/markets/[id]/route.ts
+++ b/app/api/markets/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server"
+import { getMarketById } from "@/lib/db/database"
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const market = getMarketById(params.id)
+
+  if (!market) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  return NextResponse.json(market)
+}
+

--- a/app/api/markets/route.ts
+++ b/app/api/markets/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server"
+import { addMarket, getAllMarkets } from "@/lib/db/database"
+import { Market, PredictionOption } from "@/app/auth/auth-context"
+
+export async function GET() {
+  const markets = getAllMarkets()
+  return NextResponse.json(markets)
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const marketId = `market_${Date.now()}`
+
+    const options: PredictionOption[] = (body.options || []).map(
+      (opt: any, index: number) => ({
+        id: `option_${marketId}_${index}`,
+        name: opt.name,
+        percentage: 0,
+        tokens: 0,
+        color: opt.color,
+      })
+    )
+
+    const market: Market = {
+      id: marketId,
+      title: body.title,
+      description: body.description,
+      category: body.category,
+      options,
+      startDate: new Date(),
+      endDate: new Date(body.endDate),
+      status: "active",
+      totalTokens: 0,
+      participants: 0,
+    }
+
+    addMarket(market)
+    return NextResponse.json(market, { status: 201 })
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to create market" },
+      { status: 500 }
+    )
+  }
+}
+

--- a/app/markets/[id]/page.tsx
+++ b/app/markets/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react"
 import { useParams, useRouter } from "next/navigation"
-import { getMarketById, getAllMarkets } from "../create/market-service"
 import { Market } from "@/app/auth/auth-context"
 import { MarketDetailView } from "./market-detail-view"
 import { Card } from "@/components/ui/card"
@@ -24,13 +23,15 @@ export default function MarketDetailPage() {
       
       try {
         const marketId = params.id as string
-        const foundMarket = getMarketById(marketId)
-        
-        if (!foundMarket) {
+        const res = await fetch(`/api/markets/${marketId}`)
+
+        if (!res.ok) {
           setError("Market not found")
-        } else {
-          setMarket(foundMarket)
+          return
         }
+
+        const data: Market = await res.json()
+        setMarket(data)
       } catch (err) {
         console.error("Failed to load market:", err)
         setError("Failed to load market")

--- a/app/markets/[id]/related-markets.tsx
+++ b/app/markets/[id]/related-markets.tsx
@@ -6,7 +6,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Market } from "@/app/auth/auth-context"
-import { getAllMarkets } from "../create/market-service"
 import { 
   Sparkles, 
   ArrowRight, 
@@ -27,18 +26,17 @@ export function RelatedMarkets({ currentMarket }: RelatedMarketsProps) {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    const loadRelatedMarkets = () => {
+    const loadRelatedMarkets = async () => {
       setIsLoading(true)
       try {
-        const allMarkets = getAllMarkets()
-        
-        // Filter out the current market
-        const otherMarkets = allMarkets.filter(market => market.id !== currentMarket.id)
-        
-        // Find related markets based on category and other criteria
+        const res = await fetch("/api/markets")
+        const allMarkets: Market[] = await res.json()
+
+        const otherMarkets = allMarkets.filter(
+          market => market.id !== currentMarket.id
+        )
         const related = findRelatedMarkets(otherMarkets, currentMarket)
-        
-        setRelatedMarkets(related.slice(0, 4)) // Show up to 4 related markets
+        setRelatedMarkets(related.slice(0, 4))
       } catch (error) {
         console.error("Failed to load related markets:", error)
       } finally {

--- a/lib/db/database.ts
+++ b/lib/db/database.ts
@@ -1,0 +1,18 @@
+import { Market } from "@/app/auth/auth-context"
+
+// Simple in-memory store for markets.
+// In a real application this would connect to an actual database.
+let markets: Market[] = []
+
+export function getAllMarkets(): Market[] {
+  return markets
+}
+
+export function getMarketById(id: string): Market | null {
+  return markets.find(market => market.id === id) || null
+}
+
+export function addMarket(market: Market): Market {
+  markets.push(market)
+  return market
+}


### PR DESCRIPTION
## Summary
- route market creation through new /api/markets endpoint backed by in-memory store
- submit create form to API and redirect to new market with success/error handling
- fetch market details and related markets from the API instead of sample data

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a24aa971fc832eb3ac208973a0a919