### PR TITLE
fix: resolve Firebase initialization errors in auth service

### DIFF
--- a/lib/auth/auth-service.ts
+++ b/lib/auth/auth-service.ts
@@ -79,6 +79,12 @@ class AuthService {
         return null
       }
 
+      // Check if Firebase is initialized
+      if (!db) {
+        console.error('Firebase database not initialized')
+        return null
+      }
+
       // Get Firebase UID from wallet address mapping
       const { WalletUidMappingService } = await import('@/lib/services/wallet-uid-mapping')
       const firebaseUid = await WalletUidMappingService.getFirebaseUid(address)
@@ -145,6 +151,11 @@ class AuthService {
       }
       if (!email || typeof email !== 'string') {
         throw new Error('Invalid email provided to createUserFromCDP')
+      }
+
+      // Check if Firebase is initialized
+      if (!db) {
+        throw new Error('Firebase database not initialized')
       }
 
       // Get or create wallet-to-UID mapping
@@ -268,6 +279,11 @@ class AuthService {
    */
   async updateProfileByAddress(address: string, updates: Partial<AuthUser>): Promise<AuthUser> {
     try {
+      // Check if Firebase is initialized
+      if (!db) {
+        throw new Error('Firebase database not initialized')
+      }
+
       // Convert AuthUser updates to UserProfile updates
       const profileUpdates: any = {
         lastLoginAt: serverTimestamp()

--- a/lib/db/database.ts
+++ b/lib/db/database.ts
@@ -19,18 +19,31 @@ let app: any = null;
 let db: any = null;
 let analytics: any = null;
 
-// Check if we're in build mode
+// Check if we're in build mode or if Firebase config is missing
 const isBuildTime = process.env.NODE_ENV === 'production' && !process.env.VERCEL_URL && !process.env.RUNTIME;
+const hasFirebaseConfig = firebaseConfig.apiKey && firebaseConfig.projectId;
 
-if (!isBuildTime) {
-  // Initialize Firebase
-  app = initializeApp(firebaseConfig);
-  
-  // Initialize Firebase services
-  db = getFirestore(app);
-  
-  // Initialize Analytics (only in browser)
-  analytics = typeof window !== 'undefined' ? getAnalytics(app) : null;
+if (!isBuildTime && hasFirebaseConfig) {
+  try {
+    // Initialize Firebase
+    app = initializeApp(firebaseConfig);
+    
+    // Initialize Firebase services
+    db = getFirestore(app);
+    
+    // Initialize Analytics (only in browser)
+    analytics = typeof window !== 'undefined' ? getAnalytics(app) : null;
+    
+    console.log('✅ Firebase initialized successfully');
+  } catch (error) {
+    console.error('❌ Firebase initialization failed:', error);
+    // Set to null to prevent further errors
+    app = null;
+    db = null;
+    analytics = null;
+  }
+} else {
+  console.log('⚠️ Firebase not initialized:', { isBuildTime, hasFirebaseConfig });
 }
 
 export { app, db, analytics };

--- a/lib/services/wallet-uid-mapping.ts
+++ b/lib/services/wallet-uid-mapping.ts
@@ -27,6 +27,11 @@ export class WalletUidMappingService {
     firebaseUid: string,
     email: string
   ): Promise<WalletUidMapping> {
+    // Check if Firebase is initialized
+    if (!db) {
+      throw new Error('Firebase database not initialized')
+    }
+
     const mapping: WalletUidMapping = {
       walletAddress,
       firebaseUid,
@@ -47,6 +52,12 @@ export class WalletUidMappingService {
    */
   static async getFirebaseUid(walletAddress: string): Promise<string | null> {
     try {
+      // Check if Firebase is initialized
+      if (!db) {
+        console.error('Firebase database not initialized')
+        return null
+      }
+
       const mappingDoc = await getDoc(doc(db, this.COLLECTION, walletAddress))
       
       if (mappingDoc.exists()) {
@@ -75,6 +86,12 @@ export class WalletUidMappingService {
    */
   static async findFirebaseUidByEmail(email: string): Promise<string | null> {
     try {
+      // Check if Firebase is initialized
+      if (!db) {
+        console.error('Firebase database not initialized')
+        return null
+      }
+
       // First check if we already have a mapping for this email
       const mappingsRef = collection(db, this.COLLECTION)
       const emailQuery = query(mappingsRef, where('email', '==', email))
@@ -141,6 +158,12 @@ export class WalletUidMappingService {
    */
   static async getMapping(walletAddress: string): Promise<WalletUidMapping | null> {
     try {
+      // Check if Firebase is initialized
+      if (!db) {
+        console.error('Firebase database not initialized')
+        return null
+      }
+
       const mappingDoc = await getDoc(doc(db, this.COLLECTION, walletAddress))
       return mappingDoc.exists() ? mappingDoc.data() as WalletUidMapping : null
     } catch (error) {


### PR DESCRIPTION
- Add proper Firebase database initialization checks in database.ts
- Add null checks for db object in auth-service.ts methods
- Add Firebase initialization validation in wallet-uid-mapping service
- Prevent 'Expected first argument to collection() to be a CollectionReference' errors
- Improve error handling and logging for Firebase connection issues
- Ensure graceful fallback when Firebase is not properly initialized

This fixes the console errors that occur when Firebase is not properly initialized, particularly the collection() reference errors that were breaking the auth flow.